### PR TITLE
Added *.alphalite.pro, *.gravest.site, dustgifts-list.web.app to blocklist

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2006,7 +2006,7 @@
   - url: bountyhunters.top
   - url: pawnshopgnomies.online
   - url: cursedlabs.space
-  - url: eternaldragons.top  
+  - url: eternaldragons.top
   - url: raydium-alpha.net
   - url: magicednbox.com
   - url: t00b.io
@@ -2566,3 +2566,8 @@
   - url: bk.facetious.site
   - url: hm.flabbergast.site
   - url: helium.giftlabs.live
+  - url: dustgifts-list.web.app
+  - url: lido.alphalite.pro
+  - url: bonk.alphalite.pro
+  - url: bk.gravest.site
+  - url: ld.gravest.site

--- a/nft-blocklist.yaml
+++ b/nft-blocklist.yaml
@@ -11,7 +11,7 @@
   - mint: Az9MBoFBsg3g2jiFXLVeKSPJfqAWbNzujFu2TweKPZgN
   - mint: FDGkVsQkJtNHGFSYSkbTzYJcVAbAr4eNPQPDbB9HA2Kv
   - mint: B9ZArmaKEZnBGANZGr812LSHhNPLRTefzRe1e6Hc6wa5
-  - mint: BH96UcPvksn7TF61gdwvysnYCRnH8Qrpy7jJUYvg63pu 
+  - mint: BH96UcPvksn7TF61gdwvysnYCRnH8Qrpy7jJUYvg63pu
   - mint: G3S8Hyjxi9xAnoKGNbGFb5Q3i1iJmKL9YP2fR9cv4FjH
   - mint: 68e5KZaYSvbWEm8Y2kNeeQdXFTq2HayWH8TbAfaGggNu
   - mint: 3B2VzzeKeiLX3XT8Lqgoyw2uosTGSPYYeYHTSHEzcxe3
@@ -62,7 +62,7 @@
   - mint: CJCnhVrYrijt7gVA91BiNA587qKrtQwbdZHUd2T1PeXc
   - mint: CHUzskHjG8o7dU9yNBcZQ3PRigNwQ5pm8hLpKXTB9bmd
   - mint: FuP1ZW86dDhVfTEnfFtuXCsQ4sciRvs3QC4q21ZdPUcB
-  - mint: 5hVjPnabypzuPYWVt1Ax5pFuWra5usA9jv3FSLYWBhZq 
+  - mint: 5hVjPnabypzuPYWVt1Ax5pFuWra5usA9jv3FSLYWBhZq
   - mint: 6DJrmAdZzxXFa3vVtsnwn12sULiVaWmjEcdLkhB8vcMT
   - mint: HEfwh9WmbsUSr4ZEornqrdfEoAu8LJ8sYvWBPd2orjoC
   - mint: 9XZn8VzgY1U6MCYVPv6RoQDcHxCvMLg2dojW5C9WuUdp
@@ -925,7 +925,7 @@
   - mint: 9MCTC24zujkvsMuXgWTxxf9pn4RcJbjLsSk5shYJEbxK
   - mint: 6w7kjrhMJmxS3KfS1u35nMYFhA3NMF7BRMTiPTsoBSdK
   - mint: 9yTBPr8HM5b8xASvpsQNBfHgUg49pGPZ7ZabEAnFpRN6
-  - mint: Ehvp3miLxrfDCmCoLkG8WvmzvUC6gjhZNhpgbbFqNLts 
+  - mint: Ehvp3miLxrfDCmCoLkG8WvmzvUC6gjhZNhpgbbFqNLts
   - mint: E756BMmsCv8dNAVsuvYZv1RfsLmdfpoYRu8VM8LvFrTt
   - mint: hdox9DZZZVnkxCoDDDxPgK3GsJwPEmpoKXnJZkJ9wjf
   - mint: HePYoWJJApyYTPNdwbMzFfUhumAbQ4pQUbZArDPwhpXa
@@ -967,7 +967,7 @@
   - mint: Co29sM2rNLCsuKkGeFvp4hp2MNoBejf1jaKPq4iimZUE
   - mint: J3zCykAh8YMEiELgLY8PXymtcYEzb89GvYr871ReQTv1
   - mint: Dr1xHBuazaepwYYi8X8ZzFbnwAWRvkFtJBS1WgTfn5ML
-  - mint: DfFg5E9kZVc2VFLkTxu9KwMRHwbL9BRCtEW8tZkWj4Bt 
+  - mint: DfFg5E9kZVc2VFLkTxu9KwMRHwbL9BRCtEW8tZkWj4Bt
   - mint: 6n96MGH1xhKNrVr91FqZbfkY6j3xiqyWgadApsrqtiuP
   - mint: 8VRbbHEuR6cPCWK22eG34cyp9CQn2aXGHK5HT45WcaUo
   - mint: 3TfVus43EKM2BhoUAdZHmFuaL28A3CFJbrwvVWczuFx3
@@ -996,7 +996,7 @@
   - mint: 3xvNZBS2vwZgS7KbyguExpUhHEY8ci3ytCcKDJGEW4Eu
   - mint: HqnDW3vVLZ8FXhKUVtQQJkYZPw33q7hkymb6V7TfiYXs
   - mint: fNr5nvjTr4JXW3VUNKhdT2Nn7vk5phDmc4aPhB3UpFN
-  - mint: GgLppvyMV4hezUjBysfmhgXiTTLJrHA3w1kmqR3kF4aQ 
+  - mint: GgLppvyMV4hezUjBysfmhgXiTTLJrHA3w1kmqR3kF4aQ
   - mint: 7BcxMZRoRYXfqSPa8i5unLZdTuLP3NcyAFuLPcxeBE3k
   - mint: Djg59aPup2PWU9sxDtcJ47U9UiVrBWb9JA6bqyMkeCS6
   - mint: GSNQS1o3LDYCQJ6uZDNoptALhpgTZg5gXcKPveWzoF4r
@@ -1016,7 +1016,7 @@
   - mint: 5PryQmuPWhRj1CNN62ofwZ8UdeZyLeqhvmGPVkQddPXR
   - mint: F1MHHNdAFhBS3vBykUjqy1LUbqoh8dAv6DvAqsuyhbKj
   - mint: 7VTMeX8LnhZFCjexRvyF4548aV6f7YykVQLyCy6HSqHT
-  - mint: B56JcDR6UYir7C8V9ixFBpafDmrTMtn2239i7j4AmvMr 
+  - mint: B56JcDR6UYir7C8V9ixFBpafDmrTMtn2239i7j4AmvMr
   - mint: FyWPXwM6hd7AefXvjYSNQCqaQYaw4zw5jx9tZDdXXPTZ
   - mint: 67KuLWxThvGCWRYgBstvM7Bis1pV93HPS2nzxTxTHaf1
   - mint: HJ8jb7th7p6b47gWKpMwXzdCUWLxrCnFGY9nRdKXPEEB
@@ -1368,7 +1368,7 @@
   - mint: 29mrHzomME3u3zmwv1Hm2etL6aKe7dd2N3noec5XKjz8
   - mint: 5Au2Foe238HgmaXjdjjAJSufXcBuCdKGVJtLU1kyDiBZ
   - mint: ARJEgyuByyD58t39cJvfBsjbQdga5umw2VPw7EkQFWSG
-  - mint: higb5yDaQbebeNCab9XxbVRs87J7ALuD2KKaVWh5fk9 
+  - mint: higb5yDaQbebeNCab9XxbVRs87J7ALuD2KKaVWh5fk9
   - mint: GkBrUZ4ChRyNvrcHsfC5HLsQpabYPdNty3QrSBHbbicZ
   - mint: Dhg3zgU1GqLRzFQeENUZTAz68NUxeYUZ7SjvbHWtmAPr
   - mint: 25jMfSUXR22v42WWZwD8Hb17R9pcrtE3YPEStjrcK9s
@@ -1376,7 +1376,7 @@
   - mint: CVmMUCMt9xAXr6bGZnQQFLJmbLF91XvEse1peZuDnaP3
   - mint: 8Fw2v84AxAhgSDbqktuqdiBJ1av87C4qGnEksdazxSYz
   - mint: DXe4gp8xXWQ9F9xa7VLwSYMy2hMr3ytBXpTsYQrZBagd
-  - mint: J2pf67GpNwvNWvECyba1JAbgo3zqTHz4f8Fwto13WUYW 
+  - mint: J2pf67GpNwvNWvECyba1JAbgo3zqTHz4f8Fwto13WUYW
   - mint: ECeEf4TLs2WN1g9hXfDZsvMHhLoMUwMqXe6as5rBRAca
   - mint: CzCmcZ1Q3tn9SSqWtu36n8EHFgrLYAkjkMTcHF4xCYKw
   - mint: 9TDC6WDKn1hBBuzMFC5acAQqH8oupzt6t9txnWvc1kDW
@@ -2676,3 +2676,5 @@
   - mint: 83vc7upLx8oBzinEFrkbaRfGnJaZSPatrX5k6pTdLP3P
   - mint: JDhAKmCk4mu5mV2FpkJoPg6b1Bhmi9wE5mGJoCQMX5ks
   - mint: Hch7irAEur5fYpJKSrd4cMYkromryAphVmGfxQy5NLS2
+  - mint: BiHztDxHZsxv5C7TuTh5GvHUquoZsCXw7tr5a6LqTkBo
+  - mint: 4p4Vs96xtiqQkvMmzVrxvkjWxG1asaQKnEjbMGCKrUti


### PR DESCRIPTION
Added some fishing NFT-s with their site to blocklist.
- https://solscan.io/token/4p4Vs96xtiqQkvMmzVrxvkjWxG1asaQKnEjbMGCKrUti
- https://solscan.io/token/BiHztDxHZsxv5C7TuTh5GvHUquoZsCXw7tr5a6LqTkBo
(see External Link)

For example https://lido.alphalite.pro/