### PR TITLE
Update whitelist.yaml

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -12,3 +12,5 @@
   - url: polygonventures.xyz
   - url: "*.visit.express"
   - url: "*.github.io"
+  - url: "*.ic0.app"
+  - url: "*.icp0.io"


### PR DESCRIPTION
Whitelist sites hosted on ICP blockchain, this blockchain has a public gateway for smart contracts to serve websites. 

Sadly some of these contracts are malicious and got added to the blocklist. That doesn't mean the whole gateway and all contracts on the blockchain are malicious. Considering that some projects on this blockchain also (plan to) support SOL NFTs, it would be relevant to keep the gateway whitelisted.