### PR TITLE
Add solana-summit.org to blocklist

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2644,3 +2644,4 @@
   - url: kotaworldwide.space
   - url: genoverse.top
   - url: genopets-s4.netlify.app
+  - url: solana-summit.org


### PR DESCRIPTION
Scam website associated with fake twitter account impersonating Solana Foundation

See https://twitter.com/beeman_nl/status/1680637733503467523