### PR TITLE
Update whitelist.yaml

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -17,3 +17,5 @@
   - url: "*.monstre.net"
   - url: fatcatsupgrade.com
   - url: idle-miner.club
+  - url: "*.spheron.app"
+  - url: "*.sphn.link"


### PR DESCRIPTION
Spheron Network, as a public gateway for IPFS content, has been a key enabler for many small to medium-sized projects with its IPFS pinning/gateway services. As with the ICP gateway PR, a few contracts linked to these sites have been marked malicious and placed on the blacklist. However, it's crucial to distinguish that this does not automatically denote all contracts on the Spheron Network or the gateway itself as detrimental. Given the multitude of users and projects that depend on our gateway to access their hosted websites, it's prudent to uphold the whitelist and ensure the gateway remains accessible.