### PR TITLE
Remove btcs.love from blocklist

### DIFF
--- a/eth-blocklist.yaml
+++ b/eth-blocklist.yaml
@@ -7355,7 +7355,6 @@
   - url: coolcatsofficial.xyz
   - url: sewerpass.li-vedrop.com
   - url: abenft.info
-  - url: btcs.love
   - url: decentralnode.surge.sh
   - url: trustpad-e.com
   - url: synbridgewal.com


### PR DESCRIPTION
http://btcs.love/ is the official domain controlled by COREDAO team. It should not be on the blacklist.