### PR TITLE
Add lessfeesendgas.com to blocklist

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -1886,3 +1886,4 @@
   - url: mulbers.vercel.app
   - url: memevipz.com
   - url: alphbit.site
+  - url: lessfeesendgas.com


### PR DESCRIPTION
The site impersonates https://lessfeesandgas.org/. The scam website requires a user to connect their Phantom wallet, while the correct one has a different workflow.

I connected a burner wallet (aren't all wallets burner?) and it kept wanting me to sign some transaction even when I cancelled. Only then did I see that I'm still sleepy and went to a scam.