### PR TITLE
Update blocklist.yaml and nft-blocklist.yaml

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -1953,3 +1953,4 @@
   - url: enroll-jup.app
   - url: bybit-gift.space
   - url: bybit-award.io
+  - url: wynn-get.netlify.app

--- a/nft-blocklist.yaml
+++ b/nft-blocklist.yaml
@@ -3115,3 +3115,4 @@
   - mint: AKSQaNoVrgfxmXXH3kss1pJwVeDPVwXg6GoFHGXpTiu4
   - mint: AaksXo87HDSpmeGfoUQkMiWkoZDZiE5tWL4QK8Vh6qE7
   - mint: A9W4PMGwkBir2n7kB48oj7tSP9erg9rV85vh9tZHCcxm
+  - mint: 5iG6oEheEk9NMcJReDKgdo6RZcxZtXM6XDBja8Nipavu


### PR DESCRIPTION
Images attached below for the drainer site linked in the fake airdrop NFT I received. 

<img width="1294" alt="image" src="https://github.com/phantom/blocklist/assets/140019885/c3788a18-0c02-42c4-a984-92e247ba700d">
<img width="898" alt="image" src="https://github.com/phantom/blocklist/assets/140019885/2a806a35-5213-4677-817c-dba972b67704">
<img width="363" alt="image" src="https://github.com/phantom/blocklist/assets/140019885/9773df63-a973-4f02-8ea7-b0baf69b1f55">
<img width="366" alt="image" src="https://github.com/phantom/blocklist/assets/140019885/1887d200-16b3-4d23-8dec-7a5dfd93e7b5">

Not sure if there are mechanisms to blacklist or tag wallet addresses in Phantom, but the address that the drainer tried to send assets to is [https://solana.fm/address/4waCEQ3Ss4LLN3TKSKUKk3SmH9JM8PvhpNgaey6TjWuQ/transactions?cluster=mainnet-solanafmbeta]
