### PR TITLE
Update blocklist.yaml

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -1957,3 +1957,5 @@
   - url: solanamoble.com
   - url: autovalidateblockchain.com
   - url: nftrzn.com
+  - url: collab-award.io
+  - url: collabgift.space


### PR DESCRIPTION
First URL is displayed in the scam NFT, the second is the address it redirects to.

