### PR TITLE
Update blocklist.yaml

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -1971,3 +1971,5 @@
   - url: thepond.re
   - url: hivemapper.tech
   - url: claim-satoshivm.com
+  - url: collabaward.xyz
+  - url: ultranode-mainnet.vercel.app


### PR DESCRIPTION
collabaward[.]xyz is the new redirect for collab-award[.]io

ultranode-mainnet[...] is not a traditional drainer - it asks directly for your seed phrase or private key after "failing to connect" to your wallet.