### PR TITLE
Removing Doggyonsol from blocklist - it is not a scam

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -1996,7 +1996,6 @@
   - url: samurai-award.info
   - url: anitaonsol.com
   - url: saturnsolana.com
-  - url: doggyonsol.com
   - url: jupzz.com
   - url: 2ham.pro
   - url: meleasync.com


### PR DESCRIPTION
Removed this site from the blocklist as it is not a scam.

Twitter: https://twitter.com/DoggyinSol

Just spoke with the project creators and have verified it is not a scam - please let me know if you need other info.