### PR TITLE
Update blocklist.yaml

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2004,3 +2004,9 @@
   - url: wenwendrop.com
   - url: wentokenwen.com
   - url: defihug.online
+  - url: solanawen.com
+  - url: wencoinwen.com
+  - url: getbonk.net
+  - url: unpackgift.org
+  - url: bonus-wenwencoin.com
+  - url: enrol-jup.app


### PR DESCRIPTION
getbonk[.]net and unpackgift[.]org are bonk phishing URLs

the rest are specific to the Jupiter "wen" memecoin airdrop