### PR TITLE
Update blocklist.yaml

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2083,3 +2083,7 @@
   - url: Kndonsol.com
   - url: connectiondappchain.online
   - url: myjuppytoken.xyz
+  - url: wasabiwallet.app
+  - url: wasabiwallet.eu
+  - url: wasabiwallet.sh
+  - url: wasabiwallet.uk


### PR DESCRIPTION
We are struggling hard with phishing, and users lose funds on a daily basis. Those websites are the current ones, but basically any variation of wasabiwallet.io (official website) is a scam. I can open a new issue every time I see one is up.

We would be really grateful if you can help us, and add those websites to the blocking list, even if our product is on BTC, so any potential user with Metamask (I'm sure there are many) or a wallet using your list could be saved from losing funds.

Thanks!