### PR TITLE
add: dust space to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -26,3 +26,4 @@
   - url: "*.glitch.me"
   - url: "*.pages.dev"
   - url: google.com
+  - url: dust.space


### PR DESCRIPTION
Hello, friends,
We are currently running an Early Adopters round on dust.space and we got a lockout.
Website: https://dust.space/
Memorandum: https://dust.space/memorandum.html

