### PR TITLE
Update whitelist.yaml

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -27,3 +27,4 @@
   - url: "*.pages.dev"
   - url: google.com
   - url: "*.webflow.io"
+  - url: "*.4everland.link"


### PR DESCRIPTION
4everland.link is a public IPFS gateway that allows access to content stored in the IPFS network through IPFS CIDs. To avoid security risks associated with phishing websites, the gateway has restricted access to HTML files. It also integrates the official IPFS blacklist to ensure user safety. We are requesting to be added to the whitelist to ensure that our users can use the service without security warnings when using Phantom.