### PR TITLE
added *.ebunker.io to whitelist.yaml

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -27,3 +27,4 @@
   - url: "*.pages.dev"
   - url: google.com
   - url: "*.webflow.io"
+  - url: "*.ebunker.io"

--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -28,3 +28,4 @@
   - url: google.com
   - url: "*.webflow.io"
   - url: "*.ebunker.io"
+  - url: "*.dbunker.xyz"


### PR DESCRIPTION
Ebunker(www.ebunker.io) is an no-custody, open-source Ethereum staking pool with a mission to empower the security of the ETH network and provide a decentralized gateway for Web3. We are currently expanding our business to the SOL Ecology. So we are requesting to be added to the whitelist to ensure that our users can use the service without security warnings when using Phantom.