### PR TITLE
chungus whitelisted

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -27,3 +27,5 @@
   - url: "*.pages.dev"
   - url: google.com
   - url: "*.webflow.io"
+  - url: "*.bl1chungas.xyz"
+  - url: "*.bigchungus.xyz"


### PR DESCRIPTION
Hi,

Our project's claiming page, which is available at https://www.claim.bigchungus.xyz/ & https://www.claim.bl1chungas.xyz(staging) have been incorrectly flagged as suspicious. It's causing concern for members of our community, and we're eager to get this resolved to help put the mind's of our community members at ease.

Thank you very much,
Team BigChungus