### PR TITLE
Update whitelist.yaml

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -27,3 +27,7 @@
   - url: "*.pages.dev"
   - url: google.com
   - url: "*.webflow.io"
+  - url: "*.4everland.app"
+  - url: "*.4everland.xyz"
+  - url: "*.4everland.store"
+  - url: "*.4everland.org"


### PR DESCRIPTION
4everland.app is a website domain service provided by the web3.0 cloud computing platform 4EVERLAND Hosting. It offers front-end project hosting for developers, with all deployed websites being monitored for phishing and integrated with a blacklist library to ensure their security and availability. I am requesting to be added to the whitelist. 

4everland.store is a file access domain service provided by the web3.0 cloud computing platform 4EVERLAND Bucket. It has restricted access to HTML files and integrates a file blacklist library to ensure security. I am requesting to be added to the whitelist. 

4everland.xyz is a backup domain for 4everland.io, which is already whitelisted. I am requesting to whitelist 4everland.xyz as well, to facilitate seamless switching in case of issues with 4everland.io. 

4everland.org is the official website of the web3.0 cloud computing platform 4EVERLAND. It will support wallet login in the future. I am requesting to be added to the whitelist. Thank you!