### PR TITLE
Update whitelist.yaml

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -27,3 +27,4 @@
   - url: "*.pages.dev"
   - url: google.com
   - url: "*.webflow.io"
+  - url: "*.tokentools.app"


### PR DESCRIPTION
Our platform domain name has been incorrectly marked, which has caused concern among our community members. We are eager to address this issue to help our community members feel at ease.