### PR TITLE
please add memepump.net to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -27,3 +27,4 @@
   - url: "*.pages.dev"
   - url: google.com
   - url: "*.webflow.io"
+  - url: "*.memepump.net"


### PR DESCRIPTION
https://memepump.net
This is a launchpad on Solana with sniping feature.
It's a safe and good launchpad in high demands.