### PR TITLE
Updated whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -27,3 +27,4 @@
   - url: "*.pages.dev"
   - url: google.com
   - url: "*.webflow.io"
+  - url: "degen.express"


### PR DESCRIPTION
Hi! We're a legitimate project, a launchpad that's deployed on FTM and Base so far.
Recently we have been under attack by malicious actors it seems.
We've been mass reported on Twitter by bots, and now ended up on a blocklist on Phantom?
Any help would be appreciated - I've added our site's link to the whitelist, please review.

The following are links to our project:
https://twitter.com/degenexpress69
https://degen.express