### PR TITLE
Update whitelist.yaml

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -27,3 +27,4 @@
   - url: "*.pages.dev"
   - url: google.com
   - url: "*.webflow.io"
+  - url: "enterthewormhole.io"


### PR DESCRIPTION
enterthewormhole.io is a valid wormhole project domain for a marketing campaign as mentioned
[in this tweet](https://twitter.com/wormhole/status/1788199929313456576)

See also: MetaMask/eth-phishing-detect#58416