### PR TITLE
Update whitelist.yaml

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -27,3 +27,4 @@
   - url: "*.pages.dev"
   - url: google.com
   - url: "*.webflow.io"
+  - url: bendogstaking.xyz


### PR DESCRIPTION
Added domain bendogstaking.xyz into whitelist.yaml

We have found out that in case of any transactions connected with our product they are flagged as a scam ones, that badly influences our image in front of our auience. We have official partnerships with credible partners like Solana Mobile, HotDao, NearWallet ets., moreover there are a lot of legit products are implemented into the brand Ben the Dog, so we would like to solve the issue as soon as possible. We had some copyright concerns in the past but this case was solved, so as for now there is no reason or doubts connected with our brand credibility.

Here is the official twitter aacount 
https://x.com/ben_dog_

Official website:
https://bendog.io where there is a link to staking