### PR TITLE
Update whitelist.yaml

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -27,3 +27,4 @@
   - url: "*.pages.dev"
   - url: google.com
   - url: "*.webflow.io"
+  - url: "lampedusacoin.com"


### PR DESCRIPTION
Hello,

I'm opening this pull request to request the removal of the website lampedusacoin.com from Phantom Wallet's blocklist. The site has been mistakenly flagged as malicious, despite being safe and containing no harmful or phishing content. Additionally, the connection is encrypted using HTTPS standards. It is a legitimate site that promotes the sale of Lampedusa Coin.

Furthermore, I would like to add that our official account is X Account.

Please consider removing this URL from the blocklist and adding it to the whitelist.

Thank you for your attention.