### PR TITLE
Whitelist fryfoundation.com

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2249,3 +2249,4 @@
   - url: solanagreenland.com
   - url: bark-sol.com
   - url: zmorris.net
+  - url: fryfoundation.app

--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -27,3 +27,4 @@
   - url: "*.pages.dev"
   - url: google.com
   - url: "*.webflow.io"
+  - url: "*.fryfoundation.com*"


### PR DESCRIPTION
This pull whitelists fryfoundation.com as it is being falsely blocked by phantom

The Fry Foundation is one of the biggest projects on Algorand and is 100% legit

I for some reason could not find fryfoundation.com in any of the .yaml files but phantom continues to block it. This is why I have added it to the whitelist

Also, I have added fryfoundation.app to the blocklist as it is a URL that is trying to phish fry foundation users