### PR TITLE
Update whitelist.yaml

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -29,3 +29,5 @@
   - url: "*.webflow.io"
   - url: "*.tistory.com"
   - url: "*.surge.sh"
+  - url: "*.4everland.store"
+  


### PR DESCRIPTION
4everland.store is a file access domain service provided by the web3.0 cloud computing platform 4EVERLAND Bucket. It has restricted access to HTML files and integrates a file blacklist library to ensure security. I am requesting to be added to the whitelist.