### PR TITLE
Update whitelist.yaml

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -29,3 +29,4 @@
   - url: "*.webflow.io"
   - url: "*.tistory.com"
   - url: "*.surge.sh"
+  - url: "*.4everland.xyz"


### PR DESCRIPTION
4everland.xyz is a backup domain for 4everland.io, which is already whitelisted. I am requesting to whitelist 4everland.xyz as well, to facilitate seamless switching in case of issues with 4everland.io.