### PR TITLE
Update whitelist.yaml

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -29,3 +29,4 @@
   - url: "*.webflow.io"
   - url: "*.tistory.com"
   - url: "*.surge.sh"
+  - url: "borpatoken.com"


### PR DESCRIPTION
Seems https://borpatoken.com/ has been flagged by Phantom, adding it to the whitelist.

Socials are here: https://twitter.com/borpatokencom.