### PR TITLE
Update blocklist.yaml

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2278,3 +2278,14 @@
   - url: swiftdog-fd555.web.app
   - url: nodeaccess.pages.dev
   - url: claims-sealana.pages.dev
+  - url: solana-mixer.to
+  - url: sol-mixer.com
+  - url: solanamixer.com
+  - url: mixsol.so
+  - url: usdt-solana-mixer.com
+  - url: solana-usdt-mixer.com
+  - url: usdc-mixer.com
+  - url: usdcmixer.com
+  - url: usdt-mixers.com
+  - url: usdtmixers.com
+  - url: sol-mixer.com


### PR DESCRIPTION
- solana-mixer[.to] (Scam Mixer, Already BL by Metamask: Added phishing websites MetaMask/eth-phishing-detect#26175 )
- solanamixer[.com] (Scam Mixer, Redirect from solanamix.com: Already BL by Metamask:Added phishing websites MetaMask/eth-phishing-detect#26175 and reported on btctalk: https://bitcointalk.org/index.php?topic=5486906.msg63731216#msg63731216 )
- mixsol[.so] (Scam Mixer)
- sol-mixer[.com] (Scam Mixer)
- usdt-solana-mixer[.com] (Scam Mixer)
- solana-usdt-mixer[.com] (Scam Mixer)
- usdc-mixer[.com] (Scam Mixer)
- usdcmixer[.com] (Scam Mixer)
- usdt-mixers[.com] (Scam Mixer)
- usdtmixers[.com] (Scam Mixer)
- sol-mixer[.com] (Scam Mixer)