### PR TITLE
feat: Adds Avail to allowlist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,3 +30,5 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
+  - url: "*.avail.so"
+  - url: "*.avail.tools"


### PR DESCRIPTION
Dead Phantom support team,
Please find this PR to allowlist avail domains.

Check over our social media:
Github: https://github.com/availproject
Avail's Network Info: https://docs.availproject.org/docs/networks
Site: https://www.availproject.org/
Bridge: https://bridge.avail.so
X: https://x.com/AvailProject
LinkedIn: https://www.linkedin.com/company/availproject/