### PR TITLE
Add unstake.it to blocklist

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2281,3 +2281,4 @@
   - url: 8ffjdp-5000.csb.app
   - url: tea-defi-protocol.vercel.app
   - url: blockunified-app.pages.dev
+  - url: unstake.it


### PR DESCRIPTION
Sanctum report that they've lost control of this domain and it's now hosting a scam: https://x.com/sanctumso/status/1818152146342408332