### PR TITLE
add pambii quest to whitelist in phantom

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,3 +30,4 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
+  - url: pambii.quest


### PR DESCRIPTION
Pambii is an airdrop listing platform on Solana. Our website is pambii.quest and we would like to whitelist our website on the Phantom wallet to help our campaign listers to easily make listing fee via your wallet.