### PR TITLE
Add WalletConnect domains to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,3 +30,9 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
+  - url: *.walletconnect.com
+  - url: *.walletconnect.org
+  - url: *.web3modal.com
+  - url: *.web3modal.org
+  - url: *.web3inbox.com
+  - url: *.web3inbox.org


### PR DESCRIPTION
This adds WalletConnect's domains to the whitelist to prevent any accidental blockage