### PR TITLE
Adding shillstack.com to whitelist.yaml

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -36,3 +36,4 @@
   - url: *.web3modal.org
   - url: *.web3inbox.com
   - url: *.web3inbox.org
+  - url: shillstack.com

--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,10 +30,10 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
-  - url: *.walletconnect.com
-  - url: *.walletconnect.org
-  - url: *.web3modal.com
-  - url: *.web3modal.org
-  - url: *.web3inbox.com
-  - url: *.web3inbox.org
+  - url: "*.walletconnect.com"
+  - url: "*.walletconnect.org"
+  - url: "*.web3modal.com"
+  - url: "*.web3modal.org"
+  - url: "*.web3inbox.com"
+  - url: "*.web3inbox.org"
   - url: shillstack.com


### PR DESCRIPTION
Shillstack is a legitimate site that creates crypto memes.

Please feel free to get in contact with me if you need more details on the site. 

A simple run-down is that it uses the a React framework to render custom gifs for cryptocurrencies :) 