### PR TITLE
Shillstack.com into whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -37,3 +37,4 @@
   - url: "*.web3inbox.com"
   - url: "*.web3inbox.org"
   - url: shillstack.com
+  - url: "*.shillstack.com"

--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -36,3 +36,4 @@
   - url: *.web3modal.org
   - url: *.web3inbox.com
   - url: *.web3inbox.org
+  - url: shillstack.com

--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,10 +30,10 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
-  - url: *.walletconnect.com
-  - url: *.walletconnect.org
-  - url: *.web3modal.com
-  - url: *.web3modal.org
-  - url: *.web3inbox.com
-  - url: *.web3inbox.org
+  - url: "*.walletconnect.com"
+  - url: "*.walletconnect.org"
+  - url: "*.web3modal.com"
+  - url: "*.web3modal.org"
+  - url: "*.web3inbox.com"
+  - url: "*.web3inbox.org"
   - url: shillstack.com


### PR DESCRIPTION
Shillstack is a legitimate site that creates gifs for cryptocurrencies.