### PR TITLE
Update whitelist unblock domain: airdrop.gold

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,3 +30,4 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
+  - url: airdrop.gold


### PR DESCRIPTION
#1322 
Please unblock the domain: airdrop.gold
Our site has been mistakenly blacklisted . Please review and reopen it. We will provide any information you need. Thank you! we have google adsense and make money with that