### PR TITLE
Add solhub.io to Whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,3 +30,4 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
+  - url: solhub.io


### PR DESCRIPTION
This PR proposes to add solhub.io into Whitelist as it is a legitimate website that provides seamless way to create tokens. We have verified that our site is not present on any blocklists, and there are no known issues or reports that would warrant its exclusion. It's currently being incorrectly flagged as malicious. Thank you for your patience.