### PR TITLE
Gerbi.io is a Solana Scam site with a Scam ICO

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2295,3 +2295,4 @@
   - url: cloud-2pvgyy.vercel.app
   - url: cloud-f0dfrd.vercel.app
   - url: moo-7saxh5.vercel.app
+  - url: gerbi.io


### PR DESCRIPTION
Gerbi.io is a Solana Scam site that blocks users after they send funds. They also have a fake ICO site: token.gerbi.io and block users as soon as they start asking questions in telegram.