### PR TITLE
Add rocko[dot]pro to blocklist.yaml

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2298,3 +2298,5 @@
   - url: ma-1ijj9q.vercel.app
   - url: ma-6au9u3.vercel.app
   - url: manekidrop.online
+  - url: rocko.pro
+  - url: *.rocko.pro


### PR DESCRIPTION
rocko[dot]pro is currently being used as an email domain to scam crypto users into installing malicious software