### PR TITLE
Update whitelist.yaml

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,3 +30,4 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
+  - url: shitpost.army


### PR DESCRIPTION
The dapp does not call a contract. It is a simple token send with a memo attached of a pump.fun token. The dapp reads Tx matching criteria of Tx directed at the receiving address and then ingests into our database as a message which is then printed on the wall.

Clarity in what a transaction does is a better strategy than blocking simple token sends. Whitelisting of tokens should be done at the user level, not with PRs. This is a poor strategy for security and MetaMask has failed with it, which I know is the intent of this move.

Now progress is stalled because of an arbitrary rule from a de facto gatekeeper which has had zero impact on the amount of fraud in the space.