### PR TITLE
Update blocklist.yaml

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2303,3 +2303,4 @@
   - url: smartsolution-nodes.pages.dev
   - url: fixphantom.vercel.app
   - url: wider.guru
+  - url: ɡithub.com


### PR DESCRIPTION
You might be wondering why "ɡithub.com" is blocklisted. The answer is: it's not the real github.com, though they look similar. Still unsure? Try comparing "ɡithub.com" === "github.com" in your browser console—you'll see it returns `false`.

I used a tool I created, [EvilURL](https://github.com/glaubermagal/evilurl), to analyze the actual github.com domain. I discovered a concerning issue: some registrars allow domains with mixed character sets, enabling bad actors to create domains that look nearly identical to legitimate ones. And this specific domain "ɡithub.com" is registered and leading to a malicious website.

<img width="254" alt="image" src="https://github.com/user-attachments/assets/69471ac1-5672-401e-9592-605a8bef8405">
