### PR TITLE
Request to add travelcare.io to whitelistAdd travelcare.io to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,3 +30,8 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
+  - url: travelcare.io
+  - url: "*.travelcare.io"
+
+  
+


### PR DESCRIPTION
I request to add travelcare.io to the whitelist. Our site is a legitimate travel service platform and does not contain malicious content. It is currently being blocked by Phantom Wallet, and adding it to the whitelist would resolve this issue.