### PR TITLE
Added *.us.to in the whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,3 +30,4 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
+  - url: "*.us.to"


### PR DESCRIPTION
It's a domain that's a part of the [freedns.afraid.com](https://freedns.afraid.org/) network. It includes a lot of subdomains and most of them aren't related to anything malicious, including mine.