### PR TITLE
Whitelist paly.io

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,3 +30,4 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
+  - url: "*.paly.io"


### PR DESCRIPTION
This pull request whitelists the domain paly.io for a game running on the Solana blockchain. The game requires communication with external services hosted on this domain, and whitelisting it ensures proper functionality and security.