### PR TITLE
Added nftstorage.link in the whitelist.yaml

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,3 +30,4 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
+  - url: "nftstorage.link"


### PR DESCRIPTION
nftstorage is a reputed IPFS storage service provider.