### PR TITLE
Update blocklist.yaml

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -5,6 +5,7 @@
   - url: solvision.io
   - url: staratlas.art
   - url: starsatlas.com
+  - url: kickgo.net
   - url: sollet.cc
   - url: raydlum.io
   - url: aurorynft.com


### PR DESCRIPTION
kickgo.net is a fake cloudflare verification scam/phishing website