### PR TITLE
Update blocklist.yaml

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2319,3 +2319,8 @@
   - url: pumpp-fun.pages.dev
   - url: phantom-restorewalletteamdesk.webflow.io
   - url: dextoolwallets.on.fleek.co
+  - url: exch.cd
+  - url: exch.cy
+  - url: exch.best
+  - url: monero.forex
+  - url: darknetbible.info


### PR DESCRIPTION
Added phising domains that are impersonating eXch.net and DMbible.

More information regarding monero.forex and darknetbible can be found here. 
https://namecheapscamexpose.info/
In summary, those two domains have links to to the scam phising domains mentioned above (exch.best, exch.cy, etc)