### PR TITLE
feat: add bitget wallet official website domain

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,4 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: "*.bgw.world"


### PR DESCRIPTION
Hi Pantom team,

We are reporting a mis-tagged legitimate website: https://web3.bgw.world/. This is our official site, and it has been flagged, warning users that it might be harmful if they attempt to install the Pantom Chrome extension.

We haven’t found the domain on the blocklist.yaml, so we added our domain to the whitelist.yaml, hoping this will resolve the issue.

Please help us address this as soon as possible, as it is blocking our users. Feel free to contact us if you need any additional information.

Thank you,

Bitget Wallet Team

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added three domains to the approved URL whitelist: `*.bgw.world`, `*.bitget.site`, and `*.bgw.live`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->