### PR TITLE
Whitelist tailwindcss.com — legitimate CSS framework site

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -1,4 +1,3 @@
----
   - url: phantom.app
     versionTag: "0.13.0"
   - url: sneks.gg
@@ -31,3 +30,4 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: tailwindcss.com


### PR DESCRIPTION
## Request

Add `tailwindcss.com` to the whitelist. Users are receiving false-positive malicious site warnings when visiting the site.

## About the site

- **tailwindcss.com** is the official website for [Tailwind CSS](https://github.com/tailwindlabs/tailwindcss), one of the most widely used CSS frameworks in modern web development
- **GitHub**: https://github.com/tailwindlabs/tailwindcss — 90k+ stars
- Created and maintained by [Tailwind Labs](https://github.com/tailwindlabs)
- Used by millions of developers and companies worldwide
- No malicious activity whatsoever — this is a documentation and marketing site for an open-source CSS framework

## The issue

When users visit `tailwindcss.com`, Phantom displays a warning stating the site is blocked as malicious and unsafe. The site is not in the `blocklist.yaml` — this appears to be a false positive, possibly triggered by heuristic detection.

<img width="942" height="463" alt="image" src="https://github.com/user-attachments/assets/1b9bc6f8-e309-47d5-86e9-6ab7a6995553" />

This is clearly a false positive — Tailwind CSS is a mainstream, well-established open-source project with no connection to phishing or scam activity.

Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the whitelist with a new entry for tailwindcss.com and reorganized existing whitelist entries for improved configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->